### PR TITLE
fix: change location in IT to be 'global'

### DIFF
--- a/google-cloud-dialogflow-cx/src/test/java/com/google/cloud/dialogflow/cx/v3beta1/it/ITSystemTest.java
+++ b/google-cloud-dialogflow-cx/src/test/java/com/google/cloud/dialogflow/cx/v3beta1/it/ITSystemTest.java
@@ -110,7 +110,7 @@ public class ITSystemTest {
 
   private static final String PROJECT = ServiceOptions.getDefaultProjectId();
   private static final String ID = UUID.randomUUID().toString();
-  private static final String LOCATION = "us";
+  private static final String LOCATION = "global";
   private static final String DISPLAY_NAME = "test-" + ID.substring(0, 8);
   private static final String AGENT_TIME_ZONE = "America/Los_Angeles";
   private static final String DEFAULT_LANGUAGE_CODE = "en";


### PR DESCRIPTION
Change the location ID in integration test to be "global" instead of "us" because the former is more standardized. "us" is just a legacy usage that we supported.
