### PR TITLE
docs(samples): add try blocks to clean up resources in samples and sample tests

### DIFF
--- a/samples/snippets/src/main/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequired.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequired.java
@@ -57,9 +57,6 @@ public class ConfigureWebhookToSetFormParametersAsOptionalOrRequired implements 
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     String jsonResponseObject = gson.toJson(webhookResponse);
 
-    System.out.println("Response Object: \n");
-    System.out.println(jsonResponseObject.toString());
-
     /* {
      *   "page_info": {
      *     "form_info": {

--- a/samples/snippets/src/main/java/dialogflow/cx/CreateAgent.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/CreateAgent.java
@@ -39,6 +39,9 @@ public class CreateAgent {
     String apiEndpoint = "global-dialogflow.googleapis.com:443";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
+    // Note: close() needs to be called on the AgentsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (AgentsClient client = AgentsClient.create(agentsSettings)) {
       // Set the details of the Agent to create
       Builder build = Agent.newBuilder();

--- a/samples/snippets/src/main/java/dialogflow/cx/CreateFlow.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/CreateFlow.java
@@ -50,7 +50,10 @@ public class CreateFlow {
     }
     FlowsSettings flowsSettings = flowsSettingsBuilder.build();
 
-    // Instantiates a client
+    // Instantiates a client.
+    // Note: close() needs to be called on the FlowsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (FlowsClient flowsClient = FlowsClient.create(flowsSettings)) {
       // Set the project agent name using the projectID (my-project-id), locationID (global), and
       // agentID (UUID).

--- a/samples/snippets/src/main/java/dialogflow/cx/CreateIntent.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/CreateIntent.java
@@ -48,6 +48,9 @@ public class CreateIntent {
     IntentsSettings intentsSettings = intentsSettingsBuilder.build();
 
     // Instantiates a client
+    // Note: close() needs to be called on the IntentsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (IntentsClient intentsClient = IntentsClient.create(intentsSettings)) {
       // Set the project agent name using the projectID (my-project-id), locationID (global), and
       // agentID (UUID).

--- a/samples/snippets/src/main/java/dialogflow/cx/CreatePage.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/CreatePage.java
@@ -52,6 +52,9 @@ public class CreatePage {
     PagesSettings pagesSettings = pagesSettingsBuilder.build();
 
     // Instantiates a client
+    // Note: close() needs to be called on the PagesClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (PagesClient pagesClient = PagesClient.create(pagesSettings)) {
       // Set the flow name using the projectID (my-project-id), locationID (global), agentID (UUID)
       // and flowID (UUID).

--- a/samples/snippets/src/main/java/dialogflow/cx/CreateSimplePage.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/CreateSimplePage.java
@@ -59,6 +59,9 @@ public class CreateSimplePage {
         .setPage(pageBuilder);
 
     // Make API request to create page
+    // Note: close() needs to be called on the PagesClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (PagesClient client = PagesClient.create()) {
       response = client.createPage(createRequestBuilder.build());
       System.out.println("Successfully created page!");

--- a/samples/snippets/src/main/java/dialogflow/cx/DeletePage.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DeletePage.java
@@ -40,6 +40,10 @@ public class DeletePage {
   public static void deletePage(
       String projectId, String agentId, String flowId, String pageId, String location)
       throws IOException {
+
+    // Note: close() needs to be called on the PagesClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (PagesClient client = PagesClient.create()) {
       Builder deleteRequestBuilder = DeletePageRequest.newBuilder();
 

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntent.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntent.java
@@ -52,7 +52,11 @@ public class DetectIntent {
     SessionsSettings sessionsSettings = sessionsSettingsBuilder.build();
 
     Map<String, QueryResult> queryResults = Maps.newHashMap();
-    // Instantiates a client
+    // Instantiates a client.
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       // Set the session name using the projectID (my-project-id), locationID (global), agentID
       // (UUID), and sessionId (UUID).

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentAudioInput.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentAudioInput.java
@@ -76,6 +76,10 @@ public class DetectIntentAudioInput {
 
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session =
           SessionName.ofProjectLocationAgentSessionName(projectId, locationId, agentId, sessionId);

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentDisableWebhook.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentDisableWebhook.java
@@ -68,6 +68,10 @@ public class DetectIntentDisableWebhook {
 
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session =
           SessionName.ofProjectLocationAgentSessionName(projectId, locationId, agentId, sessionId);

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentEventInput.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentEventInput.java
@@ -62,6 +62,10 @@ public class DetectIntentEventInput {
 
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session =
           SessionName.ofProjectLocationAgentSessionName(projectId, locationId, agentId, sessionId);

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentIntentInput.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentIntentInput.java
@@ -62,6 +62,10 @@ public class DetectIntentIntentInput {
 
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session =
           SessionName.ofProjectLocationAgentSessionName(projectId, locationId, agentId, sessionId);

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentSentimentAnalysis.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentSentimentAnalysis.java
@@ -68,6 +68,10 @@ public class DetectIntentSentimentAnalysis {
 
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session =
           SessionName.ofProjectLocationAgentSessionName(projectId, locationId, agentId, sessionId);

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentStream.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentStream.java
@@ -56,6 +56,10 @@ public class DetectIntentStream {
     // Instantiates a client by setting the session name.
     // Format: `projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
     // Using the same `sessionId` between requests allows continuation of the conversation.
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session = SessionName.of(projectId, locationId, agentId, sessionId);
 

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentStreamingPartialResponse.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentStreamingPartialResponse.java
@@ -56,6 +56,10 @@ public class DetectIntentStreamingPartialResponse {
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
     // Using the same `sessionId` between requests allows continuation of the conversation.
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session = SessionName.of(projectId, locationId, agentId, sessionId);
 

--- a/samples/snippets/src/main/java/dialogflow/cx/DetectIntentSynthesizeTextToSpeechOutput.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/DetectIntentSynthesizeTextToSpeechOutput.java
@@ -71,6 +71,10 @@ public class DetectIntentSynthesizeTextToSpeechOutput {
 
     // Instantiates a client by setting the session name.
     // Format:`projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/sessions/<SessionID>`
+
+    // Note: close() needs to be called on the SessionsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (SessionsClient sessionsClient = SessionsClient.create(sessionsSettings)) {
       SessionName session =
           SessionName.ofProjectLocationAgentSessionName(projectId, locationId, agentId, sessionId);

--- a/samples/snippets/src/main/java/dialogflow/cx/ExportAgent.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ExportAgent.java
@@ -47,6 +47,9 @@ public class ExportAgent {
     String apiEndpoint = String.format("%s-dialogflow.googleapis.com:443", location);
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
+    // Note: close() needs to be called on the AgentsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (AgentsClient agentsClient = AgentsClient.create(agentsSettings)) {
       ExportAgentRequest request =
           ExportAgentRequest.newBuilder()

--- a/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
@@ -45,15 +45,13 @@ public class ListPages {
     try (PagesClient client = PagesClient.create()) {
       Builder listRequestBuilder = ListPagesRequest.newBuilder();
 
-      listRequestBuilder.setParent(
-          "projects/"
-              + projectId
-              + "/locations/"
-              + location
-              + "/agents/"
-              + agentId
-              + "/flows/"
-              + flowId);
+      String parentPath = String
+          .format("projects/%s/locations/%s/agents/%s/flow/%s",
+          projectId,
+          location,
+          agentId,
+          flowId);
+      listRequestBuilder.setParent(parentPath);
       listRequestBuilder.setLanguageCode("en");
 
       // Make API request to list all pages in the project

--- a/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
@@ -39,11 +39,11 @@ public class ListPages {
   // Lists all pages from the provided parameters
   public static void listPages(String projectId, String agentId, String flowId, String location)
       throws IOException {
-    PagesClient client = PagesClient.create();
-    Builder listRequestBuilder = ListPagesRequest.newBuilder();
+    try (PagesClient client = PagesClient.create()) {
+      Builder listRequestBuilder = ListPagesRequest.newBuilder();
 
-    listRequestBuilder.setParent(
-        "projects/"
+      listRequestBuilder.setParent(
+          "projects/"
             + projectId
             + "/locations/"
             + location
@@ -51,12 +51,15 @@ public class ListPages {
             + agentId
             + "/flows/"
             + flowId);
-    listRequestBuilder.setLanguageCode("en");
+      listRequestBuilder.setLanguageCode("en");
 
-    // Make API request to list all pages in the project
-    for (Page element : client.listPages(listRequestBuilder.build()).iterateAll()) {
-      System.out.println(element);
+      // Make API request to list all pages in the project
+      for (Page element : client.listPages(listRequestBuilder.build()).iterateAll()) {
+        System.out.println(element);
+      }
     }
+
+
   }
   // [END dialogflow_cx_list_pages]
 }

--- a/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
@@ -39,6 +39,9 @@ public class ListPages {
   // Lists all pages from the provided parameters
   public static void listPages(String projectId, String agentId, String flowId, String location)
       throws IOException {
+    // Note: close() needs to be called on the PagesClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (PagesClient client = PagesClient.create()) {
       Builder listRequestBuilder = ListPagesRequest.newBuilder();
 

--- a/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
@@ -46,7 +46,7 @@ public class ListPages {
       Builder listRequestBuilder = ListPagesRequest.newBuilder();
 
       String parentPath = String
-          .format("projects/%s/locations/%s/agents/%s/flow/%s",
+          .format("projects/%s/locations/%s/agents/%s/flows/%s",
           projectId,
           location,
           agentId,

--- a/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListPages.java
@@ -45,12 +45,9 @@ public class ListPages {
     try (PagesClient client = PagesClient.create()) {
       Builder listRequestBuilder = ListPagesRequest.newBuilder();
 
-      String parentPath = String
-          .format("projects/%s/locations/%s/agents/%s/flows/%s",
-          projectId,
-          location,
-          agentId,
-          flowId);
+      String parentPath =
+          String.format(
+              "projects/%s/locations/%s/agents/%s/flows/%s", projectId, location, agentId, flowId);
       listRequestBuilder.setParent(parentPath);
       listRequestBuilder.setLanguageCode("en");
 

--- a/samples/snippets/src/main/java/dialogflow/cx/ListTestCaseResults.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListTestCaseResults.java
@@ -57,7 +57,7 @@ public class ListTestCaseResults {
         TestCasesSettings.newBuilder()
             .setEndpoint(location + "-dialogflow.googleapis.com:443")
             .build();
-    try(TestCasesClient client = TestCasesClient.create(testCasesSettings)) {
+    try (TestCasesClient client = TestCasesClient.create(testCasesSettings)) {
       for (TestCaseResult element : client.listTestCaseResults(req.build()).iterateAll()) {
         System.out.println(element);
       }

--- a/samples/snippets/src/main/java/dialogflow/cx/ListTestCaseResults.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListTestCaseResults.java
@@ -57,10 +57,10 @@ public class ListTestCaseResults {
         TestCasesSettings.newBuilder()
             .setEndpoint(location + "-dialogflow.googleapis.com:443")
             .build();
-    TestCasesClient client = TestCasesClient.create(testCasesSettings);
-
-    for (TestCaseResult element : client.listTestCaseResults(req.build()).iterateAll()) {
-      System.out.println(element);
+    try(TestCasesClient client = TestCasesClient.create(testCasesSettings)) {
+      for (TestCaseResult element : client.listTestCaseResults(req.build()).iterateAll()) {
+        System.out.println(element);
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/dialogflow/cx/ListTestCaseResults.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListTestCaseResults.java
@@ -57,6 +57,10 @@ public class ListTestCaseResults {
         TestCasesSettings.newBuilder()
             .setEndpoint(location + "-dialogflow.googleapis.com:443")
             .build();
+
+    // Note: close() needs to be called on the TestCasesClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (TestCasesClient client = TestCasesClient.create(testCasesSettings)) {
       for (TestCaseResult element : client.listTestCaseResults(req.build()).iterateAll()) {
         System.out.println(element);

--- a/samples/snippets/src/main/java/dialogflow/cx/ListTrainingPhrases.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/ListTrainingPhrases.java
@@ -38,6 +38,10 @@ public class ListTrainingPhrases {
   // DialogFlow API List Training Phrases sample.
   public static void listTrainingPhrases(
       String projectId, String location, String agentId, String intentId) throws IOException {
+
+    // Note: close() needs to be called on the IntentsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (IntentsClient client = IntentsClient.create()) {
       // Set the intent name
       IntentName name = IntentName.of(projectId, location, agentId, intentId);

--- a/samples/snippets/src/main/java/dialogflow/cx/UpdateIntent.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/UpdateIntent.java
@@ -41,6 +41,10 @@ public class UpdateIntent {
   public static void updateIntent(
       String projectId, String agentId, String intentId, String location, String displayName)
       throws IOException {
+
+    // Note: close() needs to be called on the IntentsClient object to clean up resources
+    // such as threads. In the example below, try-with-resources is used,
+    // which automatically calls close().
     try (IntentsClient client = IntentsClient.create()) {
       String intentPath =
           "projects/"

--- a/samples/snippets/src/main/java/dialogflow/cx/WebhookConfigureSessionParameters.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/WebhookConfigureSessionParameters.java
@@ -49,9 +49,6 @@ public class WebhookConfigureSessionParameters implements HttpFunction {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     String jsonResponseObject = gson.toJson(webhookResponse);
 
-    System.out.println("Session Parameter Info: \n");
-    System.out.println(jsonResponseObject.toString());
-
     /** { "session_info": { "parameters": { "order_number": "12345" } } } */
     BufferedWriter writer = response.getWriter();
     // Sends the webhookResponseObject

--- a/samples/snippets/src/main/java/dialogflow/cx/WebhookValidateFormParameter.java
+++ b/samples/snippets/src/main/java/dialogflow/cx/WebhookValidateFormParameter.java
@@ -65,8 +65,6 @@ public class WebhookValidateFormParameter implements HttpFunction {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     String jsonResponseObject = gson.toJson(webhookResponse);
 
-    System.out.println("Response Object: \n");
-    System.out.println(jsonResponseObject.toString());
     /**
      * { "page_info": { "form_info": { "parameter_info": [ { "display_name": "order_number",
      * "required": "true", "state": "INVALID", "value": "123" } ] } }, "session_info": {

--- a/samples/snippets/src/test/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT.java
@@ -65,7 +65,8 @@ public class ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT {
   public void helloHttp_bodyParamsPost() throws IOException, Exception {
 
     FulfillmentInfo fulfillmentInfo =
-        FulfillmentInfo.newBuilder().setTag("configure-form-parameters-optional-or-parameter").build();
+        FulfillmentInfo.newBuilder()
+            .setTag("configure-form-parameters-optional-or-parameter").build();
 
     WebhookRequest webhookRequest =
         WebhookRequest.newBuilder().setFulfillmentInfo(fulfillmentInfo).build();

--- a/samples/snippets/src/test/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT.java
@@ -65,7 +65,7 @@ public class ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT {
   public void helloHttp_bodyParamsPost() throws IOException, Exception {
 
     FulfillmentInfo fulfillmentInfo =
-        FulfillmentInfo.newBuilder().setTag("configure-session-parameters").build();
+        FulfillmentInfo.newBuilder().setTag("configure-form-parameters-optional-or-parameter").build();
 
     WebhookRequest webhookRequest =
         WebhookRequest.newBuilder().setFulfillmentInfo(fulfillmentInfo).build();

--- a/samples/snippets/src/test/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT.java
@@ -94,5 +94,6 @@ public class ConfigureWebhookToSetFormParametersAsOptionalOrRequiredIT {
     String expectedResponse = gson.toJson(webhookResponse);
 
     assertThat(responseOut.toString()).isEqualTo(expectedResponse);
+    Thread.sleep(200);
   }
 }

--- a/samples/snippets/src/test/java/dialogflow/cx/CreateAgentIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/CreateAgentIT.java
@@ -48,12 +48,12 @@ public class CreateAgentIT {
     String apiEndpoint = "global-dialogflow.googleapis.com:443";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
-    AgentsClient client = AgentsClient.create(agentsSettings);
+    try (AgentsClient client = AgentsClient.create(agentsSettings)) {
+      client.deleteAgent(CreateAgentIT.agentPath);
 
-    client.deleteAgent(CreateAgentIT.agentPath);
-
-    // Small delay to prevent reaching quota limit of requests per minute
-    Thread.sleep(250);
+      // Small delay to prevent reaching quota limit of requests per minute
+      Thread.sleep(250);
+    }
   }
 
   @Test

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -95,9 +95,7 @@ public class PageManagementIT {
     String name = "temp_page_" + UUID.randomUUID().toString();
     Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name);
 
-    try {
-      ListPages.listPages(PROJECT_ID, agentID, flowID, location);
-    }
+    ListPages.listPages(PROJECT_ID, agentID, flowID, location);
     assertThat(stdOut.toString()).contains(name);
   }
 

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -84,19 +84,24 @@ public class PageManagementIT {
 
   @Test
   public void testCreatePage() throws IOException {
-    Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
-    pageID = p.getName().split("/")[9];
-
-    assertThat(p.getDisplayName()).isEqualTo(displayName);
+      try {
+        Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
+        pageID = p.getName().split("/")[9];
+        assertThat(p.getDisplayName()).isEqualTo(displayName);
+      }
   }
 
   @Test
   public void testListPages() throws IOException {
     String name = "temp_page_" + UUID.randomUUID().toString();
-    Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name);
-
-    ListPages.listPages(PROJECT_ID, agentID, flowID, location);
-    assertThat(stdOut.toString()).contains(name);
+    // Page p
+    try {
+      CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name);
+      ListPages.listPages(PROJECT_ID, agentID, flowID, location);
+      assertThat(stdOut.toString()).contains(name);
+    } catch (Exception e) {
+      assertThat(e).isEqualTo("");
+    }
   }
 
   @Test

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -84,9 +84,9 @@ public class PageManagementIT {
 
   @Test
   public void testCreatePage() throws IOException {
-    Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
-    pageID = p.getName().split("/")[9];
-
+    try (Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName)) {
+      pageID = p.getName().split("/")[9];
+    }
     assertThat(p.getDisplayName()).isEqualTo(displayName);
   }
 
@@ -94,9 +94,7 @@ public class PageManagementIT {
   public void testListPages() throws IOException {
     String name = "temp_page_" + UUID.randomUUID().toString();
 
-    Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name);
-
-    try {
+    try (Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name)) {
       ListPages.listPages(PROJECT_ID, agentID, flowID, location)
     }
     assertThat(stdOut.toString()).contains(name);

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -84,9 +84,9 @@ public class PageManagementIT {
 
   @Test
   public void testCreatePage() throws IOException {
-    try (Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName)) {
-      pageID = p.getName().split("/")[9];
-    }
+    Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
+    pageID = p.getName().split("/")[9];
+
     assertThat(p.getDisplayName()).isEqualTo(displayName);
   }
 

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -47,21 +47,25 @@ public class PageManagementIT {
   public static void setUp() throws IOException {
     stdOut = new ByteArrayOutputStream();
     System.setOut(new PrintStream(stdOut));
-    Builder build = Agent.newBuilder();
-    build.setDefaultLanguageCode("en");
-    build.setDisplayName("temp_agent_" + UUID.randomUUID().toString());
-    build.setTimeZone("America/Los_Angeles");
-
-    Agent agent = build.build();
 
     String apiEndpoint = "global-dialogflow.googleapis.com:443";
-    String parentPath = "projects/" + PROJECT_ID + "/locations/global";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
-    AgentsClient client = AgentsClient.create(agentsSettings);
+    try (AgentsClient client = AgentsClient.create(agentsSettings)) {
 
-    parent = client.createAgent(parentPath, agent).getName();
-    agentID = parent.split("/")[5];
+      Builder build = Agent.newBuilder();
+      build.setDefaultLanguageCode("en");
+      build.setDisplayName("temp_agent_" + UUID.randomUUID().toString());
+      build.setTimeZone("America/Los_Angeles");
+
+      Agent agent = build.build();
+      String parentPath = "projects/" + PROJECT_ID + "/locations/global";
+
+      parent = client.createAgent(parentPath, agent).getName();
+
+      agentID = parent.split("/")[5];
+    }
+
   }
 
   @AfterClass
@@ -70,9 +74,9 @@ public class PageManagementIT {
     String parentPath = "projects/" + PROJECT_ID + "/locations/global";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
-    AgentsClient client = AgentsClient.create(agentsSettings);
-
-    client.deleteAgent(parent);
+    try (AgentsClient client = AgentsClient.create(agentsSettings)) {
+      client.deleteAgent(parent);
+    }
 
     // Small delay to prevent reaching quota limit of requests per minute
     Thread.sleep(250);

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -84,13 +84,13 @@ public class PageManagementIT {
 
   @Test
   public void testCreatePage() throws IOException {
-      try {
-        Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
-        pageID = p.getName().split("/")[9];
-        assertThat(p.getDisplayName()).isEqualTo(displayName);
-      } catch (Exception e) {
-        assertThat(e).isEqualTo("");
-      }
+    try {
+      Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
+      pageID = p.getName().split("/")[9];
+      assertThat(p.getDisplayName()).isEqualTo(displayName);
+    } catch (Exception e) {
+      assertThat(e).isEqualTo("");
+    }
   }
 
   @Test

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -88,6 +88,8 @@ public class PageManagementIT {
         Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, displayName);
         pageID = p.getName().split("/")[9];
         assertThat(p.getDisplayName()).isEqualTo(displayName);
+      } catch (Exception e) {
+        assertThat(e).isEqualTo("");
       }
   }
 

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -95,7 +95,7 @@ public class PageManagementIT {
     String name = "temp_page_" + UUID.randomUUID().toString();
 
     try (Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name)) {
-      ListPages.listPages(PROJECT_ID, agentID, flowID, location)
+      ListPages.listPages(PROJECT_ID, agentID, flowID, location);
     }
     assertThat(stdOut.toString()).contains(name);
   }

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -76,10 +76,10 @@ public class PageManagementIT {
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
     try (AgentsClient client = AgentsClient.create(agentsSettings)) {
       client.deleteAgent(parent);
-    }
 
-    // Small delay to prevent reaching quota limit of requests per minute
-    Thread.sleep(250);
+      // Small delay to prevent reaching quota limit of requests per minute
+      Thread.sleep(250);
+    }
   }
 
   @Test

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -96,7 +96,9 @@ public class PageManagementIT {
 
     Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name);
 
-    ListPages.listPages(PROJECT_ID, agentID, flowID, location);
+    try {
+      ListPages.listPages(PROJECT_ID, agentID, flowID, location)
+    }
     assertThat(stdOut.toString()).contains(name);
   }
 

--- a/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/PageManagementIT.java
@@ -93,8 +93,9 @@ public class PageManagementIT {
   @Test
   public void testListPages() throws IOException {
     String name = "temp_page_" + UUID.randomUUID().toString();
+    Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name);
 
-    try (Page p = CreateSimplePage.createPage(PROJECT_ID, agentID, flowID, location, name)) {
+    try {
       ListPages.listPages(PROJECT_ID, agentID, flowID, location);
     }
     assertThat(stdOut.toString()).contains(name);

--- a/samples/snippets/src/test/java/dialogflow/cx/UpdateIntentTest.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/UpdateIntentTest.java
@@ -48,21 +48,24 @@ public class UpdateIntentTest {
     stdOut = new ByteArrayOutputStream();
     System.setOut(new PrintStream(stdOut));
 
-    Builder build = Agent.newBuilder();
-    build.setDefaultLanguageCode("en");
-    build.setDisplayName("temp_agent_" + UUID.randomUUID().toString());
-    build.setTimeZone("America/Los_Angeles");
-
-    Agent agent = build.build();
-
     String apiEndpoint = "global-dialogflow.googleapis.com:443";
-    String parentPath = "projects/" + PROJECT_ID + "/locations/global";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
-    AgentsClient client = AgentsClient.create(agentsSettings);
+    try (AgentsClient agentsClient = AgentsClient.create(agentsSettings)) {
 
-    parent = client.createAgent(parentPath, agent).getName();
-    UpdateIntentTest.agentID = parent.split("/")[5];
+      Builder build = Agent.newBuilder();
+
+      build.setDefaultLanguageCode("en");
+      build.setDisplayName("temp_agent_" + UUID.randomUUID().toString());
+      build.setTimeZone("America/Los_Angeles");
+
+      Agent agent = build.build();
+      String parentPath = "projects/" + PROJECT_ID + "/locations/global";
+
+      parent = agentsClient.createAgent(parentPath, agent).getName();
+
+      UpdateIntentTest.agentID = parent.split("/")[5];
+    }
 
     try (IntentsClient intentsClient = IntentsClient.create()) {
       com.google.cloud.dialogflow.cx.v3.Intent.Builder intent = Intent.newBuilder();
@@ -77,14 +80,14 @@ public class UpdateIntentTest {
   public void tearDown() throws IOException, InterruptedException {
     stdOut = null;
     System.setOut(null);
+
     String apiEndpoint = "global-dialogflow.googleapis.com:443";
-    String parentPath = "projects/" + PROJECT_ID + "/locations/global";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
-    AgentsClient client = AgentsClient.create(agentsSettings);
-
-    client.deleteAgent(parent);
-
+    try(AgentsClient client = AgentsClient.create(agentsSettings)) {
+      String parentPath = "projects/" + PROJECT_ID + "/locations/global";
+      client.deleteAgent(parent);
+    }
     // Small delay to prevent reaching quota limit of requests per minute
     Thread.sleep(250);
   }

--- a/samples/snippets/src/test/java/dialogflow/cx/UpdateIntentTest.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/UpdateIntentTest.java
@@ -84,12 +84,13 @@ public class UpdateIntentTest {
     String apiEndpoint = "global-dialogflow.googleapis.com:443";
 
     AgentsSettings agentsSettings = AgentsSettings.newBuilder().setEndpoint(apiEndpoint).build();
-    try(AgentsClient client = AgentsClient.create(agentsSettings)) {
+    try (AgentsClient client = AgentsClient.create(agentsSettings)) {
       String parentPath = "projects/" + PROJECT_ID + "/locations/global";
       client.deleteAgent(parent);
+
+      // Small delay to prevent reaching quota limit of requests per minute
+      Thread.sleep(250);
     }
-    // Small delay to prevent reaching quota limit of requests per minute
-    Thread.sleep(250);
   }
 
   @Test

--- a/samples/snippets/src/test/java/dialogflow/cx/UpdateIntentTest.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/UpdateIntentTest.java
@@ -60,7 +60,7 @@ public class UpdateIntentTest {
       build.setTimeZone("America/Los_Angeles");
 
       Agent agent = build.build();
-      String parentPath = "projects/" + PROJECT_ID + "/locations/global";
+      String parentPath = String.format("projects/%s/locations/global", PROJECT_ID);
 
       parent = agentsClient.createAgent(parentPath, agent).getName();
 

--- a/samples/snippets/src/test/java/dialogflow/cx/WebhookConfigureSessionParametersIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/WebhookConfigureSessionParametersIT.java
@@ -50,7 +50,7 @@ public class WebhookConfigureSessionParametersIT {
   public void beforeTest() throws IOException {
     MockitoAnnotations.initMocks(this);
 
-    stringReader = new StringReader("{'fulfillmentInfo': {'tag': 'validate-form-parameter'}}");
+    stringReader = new StringReader("{'fulfillmentInfo': {'tag': 'configure-session-parameter'}}");
     jsonReader = new BufferedReader(stringReader);
 
     responseOut = new StringWriter();

--- a/samples/snippets/src/test/java/dialogflow/cx/WebhookConfigureSessionParametersIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/WebhookConfigureSessionParametersIT.java
@@ -82,5 +82,6 @@ public class WebhookConfigureSessionParametersIT {
     String expectedResponse = gson.toJson(webhookResponse);
 
     assertThat(responseOut.toString()).isEqualTo(expectedResponse);
+    Thread.sleep(200);
   }
 }

--- a/samples/snippets/src/test/java/dialogflow/cx/WebhookValidateFormParameterIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/WebhookValidateFormParameterIT.java
@@ -101,6 +101,6 @@ public class WebhookValidateFormParameterIT {
     String expectedResponse = gson.toJson(webhookResponse);
 
     assertThat(responseOut.toString()).isEqualTo(expectedResponse);
-    Thread.sleep(200);
+    Thread.sleep(250);
   }
 }

--- a/samples/snippets/src/test/java/dialogflow/cx/WebhookValidateFormParameterIT.java
+++ b/samples/snippets/src/test/java/dialogflow/cx/WebhookValidateFormParameterIT.java
@@ -101,5 +101,6 @@ public class WebhookValidateFormParameterIT {
     String expectedResponse = gson.toJson(webhookResponse);
 
     assertThat(responseOut.toString()).isEqualTo(expectedResponse);
+    Thread.sleep(200);
   }
 }


### PR DESCRIPTION
Change-Id: Ie68f4715646942d2e78189b3477cb9a5a31713b8

Adds try blocks to clean up resources such as threads in samples and sample tests.

Adds a helpful comment to code snippets that explains the need for either `try-with-resources` or `close()`.

```
Note: close() needs to be called on the [Client] object to clean up resources such as threads. 
In the example below, try-with-resources is used, which automatically calls close().
```
